### PR TITLE
Added ability to write to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
 - `noComments`: Boolean. If the action should only fetch Pull Requests that have 0 reviews (comments do not count).
   - Short for `Ignore PRs that have comments`.
   - **default**: false
+- `fileOutput`: String. File to which the output from `data` should be written. 
+  - Useful in the cases where the output is too big and GitHub Actions can not handle it as a variable.
 
 #### Accessing other repositories
 

--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.0.1'
+  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.0.2'

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     required: false
     description: If true, it will only collect PRs with NO reviews.
     default: false
+  fileOutput:
+    required: false
+    description: File to which the output data should be written.
 outputs:
   repo:
     description: 'The name of the repo in owner/repo pattern'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-pr-finder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "GitHub action that finds stale PRs and produce an output with them",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Added the ability to write the output of `data` to a file. It happens that if the output is too long GitHub Actions can not properly handle it and crashes.

In my case it is failing when calling the following code with the error `Argument list too long`
```yml
      - name: Write repo data
        run: echo "$DATA" > "$FILE"
        env:
          DATA: ${{ steps.pr.outputs.data }}
          FILE: outputs/${{ matrix.repo }}.json
```

This is after running on Polkadot which has more than a 100 PRs and produce a very big file.

Must be merged after #2
