### PR TITLE
made reviews request synchronous

### DIFF
--- a/src/githubApi.ts
+++ b/src/githubApi.ts
@@ -6,11 +6,12 @@ export const getPullRequestWithReviews = async (octokitInstance: github.GitHubIn
     const prs = await github.getPullRequests({ state: "open", ...repo }, { octokitInstance });
     debug(`Found a total of ${prs.length} PRs`);
 
-    const reviews = await Promise.all(prs.map(async (pr) => {
+    let reviews: PullRequest[] = [];
+    for (const pr of prs) {
         debug(`Fetching reviews for PR #${pr.number}`);
         const { data } = await octokitInstance.rest.pulls.listReviews({ pull_number: pr.number, ...repo });
-        return { ...pr, reviews: data };
-    }))
+        reviews.push({ ...pr, reviews: data });
+    }
 
     const sortedPrs = reviews.sort((a, b) => { return b.updated_at > a.updated_at ? -1 : b.updated_at < a.updated_at ? 1 : 0 });
     return sortedPrs;


### PR DESCRIPTION
If we fetch too many PRs (read 50+) and then we call the `Promise.all` method, we will be calling 50+ requests at once.

This will save the problem of too many api calls generating a rejection (`API rate limit exceeded for installation ID`).