### PR TITLE
Handling writing empty arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
   - **default**: false
 - `fileOutput`: String. File to which the output from `data` should be written. 
   - Useful in the cases where the output is too big and GitHub Actions can not handle it as a variable.
+  - Make sure that the directory exists, else it will fail
 
 #### Accessing other repositories
 

--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.0.2'
+  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.0.3'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-pr-finder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "GitHub action that finds stale PRs and produce an output with them",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Added a case where, if there are no data, it will write an empty array (`[]`) to the file.

This is useful to handle the case of reading non existing files.