### PR TITLE
Added ability to ignore drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
 - `noComments`: Boolean. If the action should only fetch Pull Requests that have 0 reviews (comments do not count).
   - Short for `Ignore PRs that have comments`.
   - **default**: false
+- `ignoreDrafts`: Boolean. If the action should ignore Pull Requests that are [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+  - **default**: true
 - `fileOutput`: String. File to which the output from `data` should be written. 
   - Useful in the cases where the output is too big and GitHub Actions can not handle it as a variable.
   - Make sure that the directory exists, else it will fail

--- a/action.yml
+++ b/action.yml
@@ -41,4 +41,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.0.3'
+  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.1.0'

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     required: false
     description: If true, it will only collect PRs with NO reviews.
     default: false
+  ignoreDrafts:
+    required: false
+    description: If true, it ignore draft Pull Requests.
+    default: true
   fileOutput:
     required: false
     description: File to which the output data should be written.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-pr-finder",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "GitHub action that finds stale PRs and produce an output with them",
   "main": "src/index.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { byNoReviews, olderThanDays } from "./filters";
 import { getPullRequestWithReviews } from "./githubApi";
 import { PullRequest, Repo } from "./types";
 
-type Filters = { daysStale: number, noReviews: boolean };
+type Filters = { daysStale: number, noReviews: boolean, ignoreDrafts: boolean };
 
 const daysSinceDate = (date: string): number => {
     return moment().diff(moment(date), 'days')
@@ -32,8 +32,10 @@ const getFiltersFromInput = (): Filters => {
 
     const noReviews = !!getInput("noComments") ? getBooleanInput("noReviews") : false;
 
+    const ignoreDrafts = !!getInput("ignoreDrafts") ? getBooleanInput("ignoreDrafts") : true;
+
     return {
-        daysStale, noReviews
+        daysStale, noReviews, ignoreDrafts
     }
 }
 
@@ -56,6 +58,9 @@ const filterPRs = (prs: PullRequest[], filters: Filters) => {
     }
     if (filters.noReviews) {
         filteredData = filteredData.filter(byNoReviews);
+    }
+    if(filters.ignoreDrafts) {
+        filteredData = filteredData.filter(pr => !pr.draft);
     }
 
     return filteredData;


### PR DESCRIPTION
This PR resolves #7 

It adds a filter to ignore draft pull request. It is `on` by default.

I also upgraded the version to `0.1.0` as it adds a feature (instead of being a fix).