### PR TITLE
Add ignoredLabels feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
   - **Important**: If set be sure to connect the names by comma.
     - Example: `feature,bug,good first issue`
     - It is **not** _case sensitive_.
+- `ignoredLabels`: Collections of labels separated by commas that should be ignored when searching for a PR.
+  - Short for `Ignore PRs with any of the required labels`.
+  - **optional**
+  - **Important**: If set be sure to connect the names by comma.
+    - Example: `feature,bug,good first issue`
+    - It is **not** _case sensitive_.
 
 #### Accessing other repositories
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     required: false
     description: Collections of labels separated by commas that should be required when searching for a PR.
     type: string
+  ignoredLabels:
+    required: false
+    description: Collections of labels separated by commas that should be ignored when searching for a PR.
+    type: string
 outputs:
   repo:
     description: 'The name of the repo in owner/repo pattern'

--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.2.0'

--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.2.0'
+  image: 'docker://ghcr.io/bretg/stale-pr-finder/action:0.3.0-alpha2'

--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-pr-finder/action:0.2.0'
+  image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -49,4 +49,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/bretg/stale-pr-finder/action:0.3.0-alpha2'
+  image: 'Dockerfile'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-pr-finder",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "description": "GitHub action that finds stale PRs and produce an output with them",
   "main": "src/index.ts",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bretg/stale-pr-finder.git"
+    "url": "git+https://github.com/paritytech/stale-pr-finder.git"
   },
   "keywords": [
     "github-action",
@@ -26,9 +26,9 @@
   "author": "Javier Bullrich <javier.bullrich@parity.io>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bretg/stale-pr-finder/issues"
+    "url": "https://github.com/paritytech/stale-pr-finder/issues"
   },
-  "homepage": "https://github.com/bretg/stale-pr-finder#readme",
+  "homepage": "https://github.com/paritytech/stale-pr-finder#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-pr-finder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GitHub action that finds stale PRs and produce an output with them",
   "main": "src/index.ts",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/paritytech/stale-pr-finder.git"
+    "url": "git+https://github.com/bretg/stale-pr-finder.git"
   },
   "keywords": [
     "github-action",
@@ -26,9 +26,9 @@
   "author": "Javier Bullrich <javier.bullrich@parity.io>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/paritytech/stale-pr-finder/issues"
+    "url": "https://github.com/bretg/stale-pr-finder/issues"
   },
-  "homepage": "https://github.com/paritytech/stale-pr-finder#readme",
+  "homepage": "https://github.com/bretg/stale-pr-finder#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -13,4 +13,4 @@ export const withLabels = (pr: PullRequest, labels: string[]): boolean =>
 
 export const withoutLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
-  pr.labels.map((l) => l.name.toLowerCase()).!some((l) => labels.map((label) => label.toLowerCase()).includes(l));
+  pr.labels.map((l) => !l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -13,4 +13,4 @@ export const withLabels = (pr: PullRequest, labels: string[]): boolean =>
 
 export const withoutLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
-  pr.labels.map((l) => l.name.toLowerCase()).some((l) => !labels.map((label) => label.toLowerCase()).includes(l));
+  pr.labels.map((l) => l.name.toLowerCase()).!some((l) => labels.map((label) => label.toLowerCase()).includes(l));

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -7,6 +7,10 @@ export const olderThanDays = (pr: PullRequest, daysStale: number): boolean =>
 
 export const byNoReviews = (pr: PullRequest): boolean => !pr.reviews || pr.reviews.length === 0;
 
-export const byLabels = (pr: PullRequest, labels: string[]): boolean =>
+export const withLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
   pr.labels.map((l) => l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));
+
+export const withoutLabels = (pr: PullRequest, labels: string[]): boolean =>
+  pr.labels &&
+  pr.labels.map((l) => l.name.toLowerCase()).some((l) => !labels.map((label) => label.toLowerCase()).includes(l));

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -13,4 +13,4 @@ export const withLabels = (pr: PullRequest, labels: string[]): boolean =>
 
 export const withoutLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
-  pr.labels.map((l) => !l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));
+  !pr.labels.map((l) => l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -9,8 +9,8 @@ export const byNoReviews = (pr: PullRequest): boolean => !pr.reviews || pr.revie
 
 export const withLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
-  pr.labels.map((l) => l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));
+  pr.labels.map((prl) => prl.name.toLowerCase()).some((prl) => labels.map((label) => label.toLowerCase()).includes(prl));
 
 export const withoutLabels = (pr: PullRequest, labels: string[]): boolean =>
   pr.labels &&
-  !pr.labels.map((l) => l.name.toLowerCase()).some((l) => labels.map((label) => label.toLowerCase()).includes(l));
+  !pr.labels.map((prl) => prl.name.toLowerCase()).some((prl) => labels.map((label) => label.toLowerCase()).includes(prl));

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,11 +70,6 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((pr) => !pr.draft);
   }
   if (filters.requiredLabels.length > 0) {
-    console.log("required labels", JSON.stringify(filters.requiredLabels));
-    filteredData.forEach(function(pr) {
-      console.log(pr.title);
-      console.log(JSON.stringify(pr.labels));
-    });
     filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
   }
   if (filters.ignoredLabels.length > 0) {
@@ -107,9 +102,8 @@ const runAction = async (ctx: Context) => {
 
   const inputDays = Number.parseInt(getInput("days-stale", { required: false }));
   const daysStale = isNaN(inputDays) ? 5 : inputDays;
-  const stale = isNaN(daysStale);
   const outputFile = getInput("fileOutput", { required: false });
-  console.log("daysStale", daysStale, stale);
+  console.log("daysStale", daysStale);
 
   const octokit = await github.getInstance({ authType: "token", authToken: token });
   const prs = await getPullRequestWithReviews(octokit, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,17 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
   }
   if (filters.ignoredLabels.length > 0) {
-    console.log("running ignored labels before: ", JSON.stringify(filteredData));
+    console.log("running ignored labels before");
+    filteredData.forEach(function (arrayItem) {
+      console.log(arrayItem.title);
+      console.log(JSON.stringify(arrayItem.labels));
+    });
     filteredData = filteredData.filter((fd) => withoutLabels(fd, filters.ignoredLabels));
-    console.log("running ignored labels after: ", JSON.stringify(filteredData));
+    console.log("running ignored labels after");
+    filteredData.forEach(function (arrayItem) {
+      console.log(arrayItem.title);
+      console.log(JSON.stringify(arrayItem.labels));
+    });
   }
 
   return filteredData;
@@ -107,7 +115,7 @@ const runAction = async (ctx: Context) => {
   const daysStale = isNaN(inputDays) ? 5 : inputDays;
   const stale = isNaN(daysStale);
   const outputFile = getInput("fileOutput", { required: false });
-  console.log("daysStale2", daysStale, stale);
+  console.log("daysStale3", daysStale, stale);
 
   const octokit = await github.getInstance({ authType: "token", authToken: token });
   const prs = await getPullRequestWithReviews(octokit, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ const runAction = async (ctx: Context) => {
   const daysStale = isNaN(inputDays) ? 5 : inputDays;
   const stale = isNaN(daysStale);
   const outputFile = getInput("fileOutput", { required: false });
-  console.log("daysStale", daysStale, stale);
+  console.log("daysStale2", daysStale, stale);
 
   const octokit = await github.getInstance({ authType: "token", authToken: token });
   const prs = await getPullRequestWithReviews(octokit, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,17 +74,7 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
   }
   if (filters.ignoredLabels.length > 0) {
-    console.log("running ignored labels before");
-    filteredData.forEach(function (arrayItem) {
-      console.log(arrayItem.title);
-      console.log(JSON.stringify(arrayItem.labels));
-    });
     filteredData = filteredData.filter((fd) => withoutLabels(fd, filters.ignoredLabels));
-    console.log("running ignored labels after");
-    filteredData.forEach(function (arrayItem) {
-      console.log(arrayItem.title);
-      console.log(JSON.stringify(arrayItem.labels));
-    });
   }
 
   return filteredData;
@@ -115,7 +105,7 @@ const runAction = async (ctx: Context) => {
   const daysStale = isNaN(inputDays) ? 5 : inputDays;
   const stale = isNaN(daysStale);
   const outputFile = getInput("fileOutput", { required: false });
-  console.log("daysStale3", daysStale, stale);
+  console.log("daysStale4", daysStale, stale);
 
   const octokit = await github.getInstance({ authType: "token", authToken: token });
   const prs = await getPullRequestWithReviews(octokit, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,11 @@ import { github } from "@eng-automation/integrations";
 import { writeFile } from "fs";
 import moment from "moment";
 
-import { byLabels, byNoReviews, olderThanDays } from "./filters";
+import { withLabels, withoutLabels, byNoReviews, olderThanDays } from "./filters";
 import { getPullRequestWithReviews } from "./githubApi";
 import { PullRequest, Repo } from "./types";
 
-type Filters = { daysStale: number; noReviews: boolean; ignoreDrafts: boolean; requiredLabels: string[] };
+type Filters = { daysStale: number; noReviews: boolean; ignoreDrafts: boolean; requiredLabels: string[], ignoredLabels: string[] };
 
 const daysSinceDate = (date: string): number => moment().diff(moment(date), "days");
 
@@ -33,12 +33,19 @@ const getFiltersFromInput = (): Filters => {
   const ignoreDrafts = getInput("ignoreDrafts") ? getBooleanInput("ignoreDrafts") : true;
 
   let requiredLabels: string[] = [];
-  const labels = getInput("requiredLabels");
+  let ignoredLabels: string[] = [];
+  let labels = getInput("requiredLabels");
   if (labels) {
     requiredLabels = labels.split(",");
   }
 
-  return { daysStale, noReviews, ignoreDrafts, requiredLabels };
+  let labels = getInput("ignoredLabels");
+  if (labels) {
+    ignoredLabels = labels.split(",");
+  }
+  
+
+  return { daysStale, noReviews, ignoreDrafts, requiredLabels, ignoredLabels };
 };
 
 const generateMarkdownMessage = (prs: PullRequest[], repo: { owner: string; repo: string }) => {
@@ -64,7 +71,10 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((pr) => !pr.draft);
   }
   if (filters.requiredLabels.length > 0) {
-    filteredData = filteredData.filter((fd) => byLabels(fd, filters.requiredLabels));
+    filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
+  }
+  if (filters.ignoredLabels.length > 0) {
+    filteredData = filteredData.filter((fd) => withoutLabels(fd, filters.ignoredLabels));
   }
 
   return filteredData;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const getFiltersFromInput = (): Filters => {
     requiredLabels = labels.split(",");
   }
 
-  let labels = getInput("ignoredLabels");
+  labels = getInput("ignoredLabels");
   if (labels) {
     ignoredLabels = labels.split(",");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ const getFiltersFromInput = (): Filters => {
 
   labels = getInput("ignoredLabels");
   if (labels) {
-    console.log("ignoredLabels: ",labels);
     ignoredLabels = labels.split(",");
   }
   
@@ -105,7 +104,7 @@ const runAction = async (ctx: Context) => {
   const daysStale = isNaN(inputDays) ? 5 : inputDays;
   const stale = isNaN(daysStale);
   const outputFile = getInput("fileOutput", { required: false });
-  console.log("daysStale4", daysStale, stale);
+  console.log("daysStale", daysStale, stale);
 
   const octokit = await github.getInstance({ authType: "token", authToken: token });
   const prs = await getPullRequestWithReviews(octokit, repo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,11 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((pr) => !pr.draft);
   }
   if (filters.requiredLabels.length > 0) {
+    console.log("required labels", JSON.stringify(requiredLabels));
+    filteredData.forEach(function(pr) {
+      console.log(pr.title);
+      console.log(JSON.stringify(pr.labels));
+    });
     filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
   }
   if (filters.ignoredLabels.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((pr) => !pr.draft);
   }
   if (filters.requiredLabels.length > 0) {
-    console.log("required labels", JSON.stringify(requiredLabels));
+    console.log("required labels", JSON.stringify(filters.requiredLabels));
     filteredData.forEach(function(pr) {
       console.log(pr.title);
       console.log(JSON.stringify(pr.labels));

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,10 @@ const getFiltersFromInput = (): Filters => {
 
   labels = getInput("ignoredLabels");
   if (labels) {
+    console.log("ignoredLabels: ",labels);
     ignoredLabels = labels.split(",");
   }
   
-
   return { daysStale, noReviews, ignoreDrafts, requiredLabels, ignoredLabels };
 };
 
@@ -74,7 +74,9 @@ const filterPRs = (prs: PullRequest[] | undefined, filters: Filters) => {
     filteredData = filteredData.filter((fd) => withLabels(fd, filters.requiredLabels));
   }
   if (filters.ignoredLabels.length > 0) {
+    console.log("running ignored labels before: ", JSON.stringify(filteredData));
     filteredData = filteredData.filter((fd) => withoutLabels(fd, filters.ignoredLabels));
+    console.log("running ignored labels after: ", JSON.stringify(filteredData));
   }
 
   return filteredData;


### PR DESCRIPTION
We're planning to use Stale PR Finder to help manage the backlogs for the open source project https://github.com/prebid, but we needed to ability to flag certain PRs as excluded from being considered stale. Added the `ignoredLabels` feature for your consideration.

Thank you.